### PR TITLE
Fix: [AEA-0000] - do not need environment for gh pages update

### DIFF
--- a/.github/workflows/cdk_release_code.yml
+++ b/.github/workflows/cdk_release_code.yml
@@ -126,7 +126,6 @@ jobs:
 
   update_github_pages:
     runs-on: ubuntu-22.04
-    environment: ${{ inputs.TARGET_ENVIRONMENT }}
     if: ${{ always() && !failure() && !cancelled() }}
     needs: [release_code]
     permissions:


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- do not need environment for gh pages update